### PR TITLE
fix wrong and misleading assertion message

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ logCapture.assertLoggedInOrder(
   * [Cucumber example](#cucumber-example)
     * [Cucumber feature file](#cucumber-feature-file)
 * [Changes](#changes)
+  * [3.6.1](#361)
   * [3.6.0](#360)
   * [3.5.0](#350)
   * [3.4.1](#341)
@@ -72,7 +73,7 @@ Add log-capture as a test dependency to your project. If you use Maven, add this
 <dependency>
     <groupId>de.dm.infrastructure</groupId>
     <artifactId>log-capture</artifactId>
-    <version>3.6.0</version>
+    <version>3.6.1</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -307,6 +308,10 @@ And with MDC logging context
 ```
 
 ## Changes
+
+### 3.6.1
+
+* Fixed a misleading and wrong assertion message. The assertion itself was correct, but the message always said all matchers did not match when only a subset did not match.
 
 ### 3.6.0
 

--- a/src/main/java/de/dm/infrastructure/logcapture/LogAsserter.java
+++ b/src/main/java/de/dm/infrastructure/logcapture/LogAsserter.java
@@ -202,11 +202,13 @@ public class LogAsserter {
         StringBuilder assertionMessage = new StringBuilder();
 
         for (LogEventMatcher logEventMatcher : logEventMatchers) {
-            assertionMessage.append(format("Expected log message has occurred, but never with the expected %s: %s",
-                    logEventMatcher.getMatcherTypeDescription(), getDescriptionForExpectedMessage(level, regex)));
-            assertionMessage.append(lineSeparator());
-            assertionMessage.append(logEventMatcher.getNonMatchingErrorMessage(partiallyMatchingLoggedEvent));
-            assertionMessage.append(lineSeparator());
+            if (!logEventMatcher.matches(partiallyMatchingLoggedEvent)) {
+                assertionMessage.append(format("Expected log message has occurred, but never with the expected %s: %s",
+                        logEventMatcher.getMatcherTypeDescription(), getDescriptionForExpectedMessage(level, regex)));
+                assertionMessage.append(lineSeparator());
+                assertionMessage.append(logEventMatcher.getNonMatchingErrorMessage(partiallyMatchingLoggedEvent));
+                assertionMessage.append(lineSeparator());
+            }
         }
         throw new AssertionError(assertionMessage.toString());
     }

--- a/src/test/java/de/dm/infrastructure/logcapture/FluentApiTest.java
+++ b/src/test/java/de/dm/infrastructure/logcapture/FluentApiTest.java
@@ -165,12 +165,6 @@ class FluentApiTest {
         assertThat(assertionError).hasMessage(
                 "Expected log message has occurred, but never with the expected MDC value: Level: WARN, Regex: \"bye world\"" +
                         lineSeparator() + "  captured message: \"bye world\"" +
-                        lineSeparator() + "  expected MDC key: key" +
-                        lineSeparator() + "  expected MDC value: \".*value.*\"" +
-                        lineSeparator() + "  captured MDC values:" +
-                        lineSeparator() + "    key: \"value\"" +
-                        lineSeparator() + "Expected log message has occurred, but never with the expected MDC value: Level: WARN, Regex: \"bye world\"" +
-                        lineSeparator() + "  captured message: \"bye world\"" +
                         lineSeparator() + "  expected MDC key: another_key" +
                         lineSeparator() + "  expected MDC value: \".*another_value.*\"" +
                         lineSeparator() + "  captured MDC values:" +


### PR DESCRIPTION
(the message always suggested all matchers did not match when only a subset did not match)